### PR TITLE
Feat closeout division

### DIFF
--- a/Database/sp_CloseDivision.sql
+++ b/Database/sp_CloseDivision.sql
@@ -1,0 +1,17 @@
+USE ftbbl;
+DROP PROCEDURE IF EXISTS sp_CloseDivision;
+DELIMITER //
+CREATE PROCEDURE sp_CloseDivision (IN i_div_id INT)
+BEGIN
+
+	UPDATE TeamDivision
+    SET end_date = CURDATE()
+    WHERE div_id = i_div_id
+    AND end_date IS NULL;
+    
+    UPDATE Division
+    SET closed = True
+    WHERE id = i_div_id;
+
+END//
+DELIMITER ;

--- a/Database/sp_UpdateTeamDivision.sql
+++ b/Database/sp_UpdateTeamDivision.sql
@@ -1,3 +1,4 @@
+USE ftbbl;
 DROP PROCEDURE IF EXISTS sp_UpdateTeamDivision;
 DELIMITER //
 CREATE PROCEDURE sp_UpdateTeamDivision (IN i_team_id INT, IN i_div_id INT)

--- a/Frontend/src/Api.elm
+++ b/Frontend/src/Api.elm
@@ -21,6 +21,7 @@ type Endpoint
     | Race RaceId
     | Divisions
     | Division DivisionId
+    | CloseDivision DivisionId
     | Games
     | GamesInDiv DivisionId
     | Game GameId
@@ -79,6 +80,9 @@ stringOf endpoint =
 
         TeamUpdateDiv teamId divId ->
             "team/updatediv/" ++ Team.idToString teamId ++ "/" ++ Div.idToString divId
+
+        CloseDivision divId ->
+            "div/close/" ++ Div.idToString divId
 
 
 urlOf : Endpoint -> String

--- a/Frontend/src/Api.elm
+++ b/Frontend/src/Api.elm
@@ -11,6 +11,7 @@ import Model.Team as Team exposing (TeamId)
 
 type Endpoint
     = Teams
+    | FreeTeams
     | TeamsInDiv DivisionId
     | TeamsNotInDiv DivisionId
     | TeamUpdateDiv TeamId DivisionId
@@ -38,6 +39,9 @@ stringOf endpoint =
     case endpoint of
         Teams ->
             "team"
+
+        FreeTeams ->
+            "team/free/"
 
         Team index ->
             "team/" ++ Team.idToString index

--- a/Frontend/src/Custom/Attributes.elm
+++ b/Frontend/src/Custom/Attributes.elm
@@ -123,9 +123,11 @@ table =
     class "table table-striped table-hover"
 
 
-tableButtonColumn : Int -> Attribute msg
+tableButtonColumn : Int -> List (Attribute msg)
 tableButtonColumn btnCount =
-    width <| btnCount * 100
+    [ width <| btnCount * 100
+    , style "text-align" "right"
+    ]
 
 
 

--- a/Frontend/src/Header.elm
+++ b/Frontend/src/Header.elm
@@ -142,8 +142,8 @@ viewDivisionsLink divisions =
     case divisions of
         RemoteData.Success divs ->
             dropdownLink "Divisions" DivisionIndexClicked <|
-                List.map 
-                    (\div -> dropdownEntry (div.name ++ " Season " ++ String.fromInt div.season) <| SpecificDivisionClicked div.id) 
+                List.map
+                    (\div -> dropdownEntry (div.name ++ " Season " ++ String.fromInt div.season) <| SpecificDivisionClicked div.id)
                     (List.filter (\div -> not div.closed) divs)
 
         _ ->

--- a/Frontend/src/Header.elm
+++ b/Frontend/src/Header.elm
@@ -142,7 +142,9 @@ viewDivisionsLink divisions =
     case divisions of
         RemoteData.Success divs ->
             dropdownLink "Divisions" DivisionIndexClicked <|
-                List.map (\div -> dropdownEntry (div.name ++ " Season " ++ String.fromInt div.season) <| SpecificDivisionClicked div.id) divs
+                List.map 
+                    (\div -> dropdownEntry (div.name ++ " Season " ++ String.fromInt div.season) <| SpecificDivisionClicked div.id) 
+                    (List.filter (\div -> not div.closed) divs)
 
         _ ->
             linkElement "Divisions" DivisionIndexClicked

--- a/Frontend/src/Page/AddGameWeek.elm
+++ b/Frontend/src/Page/AddGameWeek.elm
@@ -8,13 +8,11 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import Http
 import Model.Division exposing (Division, DivisionId, divisionDecoder)
-import Model.Game exposing (Game, defaultGame)
+import Model.Game exposing (Game, defaultGame, gameDecoder, newGameEncoder)
 import Model.Session exposing (Session)
 import Model.Team as Team exposing (Team, defaultTeam, teamsDecoder)
 import RemoteData exposing (WebData)
 import Route exposing (pushUrl)
-import Model.Game exposing (newGameEncoder)
-import Model.Game exposing (gameDecoder)
 
 
 
@@ -92,7 +90,7 @@ update msg model =
             ( { model | games = changeAwayTeam gameIndex newTeam model.games }, Cmd.none )
 
         Submit ->
-            ( { model | submitErrors = []}, saveGames model.session.token model.games)
+            ( { model | submitErrors = [] }, saveGames model.session.token model.games )
 
         GameSubmitted (Ok _) ->
             let
@@ -109,7 +107,7 @@ update msg model =
             ( { model | successes = newSuccesses }, newCmd )
 
         GameSubmitted (Err err) ->
-            ( { model | submitErrors = (buildErrorMessage err) :: model.submitErrors }, Cmd.none )
+            ( { model | submitErrors = buildErrorMessage err :: model.submitErrors }, Cmd.none )
 
 
 searchByIdString : String -> (id -> String) -> { c | id : id } -> WebData (List { c | id : id }) -> { c | id : id }
@@ -160,7 +158,7 @@ tryCreateGames week divData teamsData =
                         gameCount =
                             List.length teams // 2
                     in
-                    List.repeat gameCount { defaultGame | division = div, week=week }
+                    List.repeat gameCount { defaultGame | division = div, week = week }
 
                 _ ->
                     []
@@ -197,6 +195,8 @@ saveGame token game =
         (Http.jsonBody (newGameEncoder game))
         (Http.expectJson GameSubmitted gameDecoder)
 
+
+
 -- View --
 
 
@@ -228,11 +228,12 @@ viewSubmitErrors errors =
     if List.length errors > 0 then
         div [ Custom.Attributes.errorMessage ]
             [ h3 [] [ text "Couldn't save a team at this time." ]
-            , text <| "Error: " ++ (List.foldl (\a b -> a ++ " " ++ b) "" errors )
+            , text <| "Error: " ++ List.foldl (\a b -> a ++ " " ++ b) "" errors
             , br [] []
             ]
-    else 
-    text ""
+
+    else
+        text ""
 
 
 viewForm : Model -> Html Msg

--- a/Frontend/src/Page/AddTeamToDiv.elm
+++ b/Frontend/src/Page/AddTeamToDiv.elm
@@ -168,11 +168,24 @@ view model =
                 [ h3 [] [ text <| "Add Team to " ++ division.name ]
                 , br [] []
                 , viewSaveError model.saveError
-                , viewFormOrError model
+                , if division.closed then
+                    closedDivError
+
+                  else
+                    viewFormOrError model
                 ]
 
         RemoteData.Failure httpError ->
             viewLoadError <| Error.buildErrorMessage httpError
+
+
+closedDivError : Html Msg
+closedDivError =
+    div [ Custom.Attributes.errorMessage ]
+        [ h3 [] [ text "Invalid Division" ]
+        , text "You cannot add a team to a division that has been closed."
+        , br [] []
+        ]
 
 
 viewFormOrError : Model -> Html Msg

--- a/Frontend/src/Page/AddTeamToDiv.elm
+++ b/Frontend/src/Page/AddTeamToDiv.elm
@@ -50,7 +50,7 @@ init session id =
       , teams = RemoteData.Loading
       }
     , Cmd.batch
-        [ getTeamsNotInDivRequest session.token id
+        [ getFreeTeamsRequest session.token
         , getDivisionRequest session.token id
         ]
     )
@@ -105,9 +105,9 @@ trySubmit token maybeTeamId divId =
 -- API Requests --
 
 
-getTeamsNotInDivRequest : Maybe String -> DivisionId -> Cmd Msg
-getTeamsNotInDivRequest token divId =
-    Api.getRequest token (Api.TeamsNotInDiv divId) <|
+getFreeTeamsRequest : Maybe String -> Cmd Msg
+getFreeTeamsRequest token =
+    Api.getRequest token Api.FreeTeams <|
         Http.expectJson (RemoteData.fromResult >> TeamsReceived) teamsDecoder
 
 

--- a/Frontend/src/Page/ListCoaches.elm
+++ b/Frontend/src/Page/ListCoaches.elm
@@ -288,7 +288,7 @@ viewCoach session coach =
         , td []
             [ text <| String.fromInt coach.elo ]
         , requiresAuth session <|
-            td ( Custom.Attributes.tableButtonColumn 2 )
+            td (Custom.Attributes.tableButtonColumn 2)
                 [ viewEditButton coach, viewDeleteButton coach ]
         ]
 

--- a/Frontend/src/Page/ListCoaches.elm
+++ b/Frontend/src/Page/ListCoaches.elm
@@ -288,7 +288,7 @@ viewCoach session coach =
         , td []
             [ text <| String.fromInt coach.elo ]
         , requiresAuth session <|
-            td [ Custom.Attributes.tableButtonColumn 2 ]
+            td ( Custom.Attributes.tableButtonColumn 2 )
                 [ viewEditButton coach, viewDeleteButton coach ]
         ]
 

--- a/Frontend/src/Page/ListDivisions.elm
+++ b/Frontend/src/Page/ListDivisions.elm
@@ -297,6 +297,8 @@ viewTableHeader sortMethod =
                 ]
             , th [ scope "col" ]
                 [ text "" ]
+            , th [ scope "col" ]
+                [ text "" ]
             ]
         ]
 
@@ -308,6 +310,13 @@ viewDivision session division =
             [ text division.name ]
         , td []
             [ text <| String.fromInt division.season ]
+        , td []
+            [ if division.closed then
+                text "Closed"
+
+              else
+                text "Ongoing"
+            ]
         , requiresAuth session <|
             td (Custom.Attributes.tableButtonColumn 3)
                 [ viewCloseButton division

--- a/Frontend/src/Page/ListDivisions.elm
+++ b/Frontend/src/Page/ListDivisions.elm
@@ -32,8 +32,10 @@ type Msg
     | DivisionsRecieved (WebData (List Division))
     | AddDivisionButtonClick
     | EditDivisionButtonClick DivisionId
+    | CloseDivisionButtonClick DivisionId
     | DeleteDivisionButtonClick DivisionId
     | DivisionDeleted (Result Http.Error DeleteResponse)
+    | DivisionClosed (Result Http.Error String)
     | ViewDivisionButtonClick DivisionId
     | NameSortClick
     | SeasonSortClick
@@ -87,10 +89,19 @@ update msg model =
         DeleteDivisionButtonClick id ->
             ( model, deleteDivisionRequest model.session.token id )
 
+        CloseDivisionButtonClick id ->
+            ( { model | deleteError = Nothing }, closeDivRequest model.session.token id )
+
         DivisionDeleted (Ok res) ->
             ( { model | deleteError = buildDeleteError res }, getDivisionsRequest model.session.token )
 
         DivisionDeleted (Err err) ->
+            ( { model | deleteError = Just (Error.buildErrorMessage err) }, Cmd.none )
+
+        DivisionClosed (Ok _) ->
+            ( { model | deleteError = Nothing }, getDivisionsRequest model.session.token )
+
+        DivisionClosed (Err err) ->
             ( { model | deleteError = Just (Error.buildErrorMessage err) }, Cmd.none )
 
         NameSortClick ->
@@ -98,6 +109,8 @@ update msg model =
 
         SeasonSortClick ->
             ( { model | sortingMethod = newSort Season SeasonDesc model.sortingMethod }, Cmd.none )
+
+        
 
 
 newSort : SortingMethod -> SortingMethod -> SortingMethod -> SortingMethod
@@ -133,7 +146,10 @@ deleteDivisionRequest token id =
     Api.deleteRequest token (Api.Division id) <|
         Http.expectJson DivisionDeleted deleteResponseDecoder
 
-
+closeDivRequest : Maybe String -> DivisionId -> Cmd Msg
+closeDivRequest token divId =
+    Api.postRequest token (Api.CloseDivision divId) Http.emptyBody <|
+        Http.expectString DivisionClosed
 
 -- Helper Functions --
 
@@ -292,8 +308,11 @@ viewDivision session division =
         , td []
             [ text <| String.fromInt division.season ]
         , requiresAuth session <|
-            td [ Custom.Attributes.tableButtonColumn 2 ]
-                [ viewEditButton division, viewDeleteButton division ]
+            td (Custom.Attributes.tableButtonColumn 3)
+                [ viewCloseButton division
+                , viewEditButton division
+                , viewDeleteButton division 
+                ]
         ]
 
 
@@ -309,3 +328,12 @@ viewEditButton division =
     button
         (onClick (EditDivisionButtonClick division.id) :: Custom.Attributes.editButton)
         [ text "Edit" ]
+
+viewCloseButton : Division -> Html Msg
+viewCloseButton division =
+    if division.closed then
+        text ""
+    else 
+        button
+        (onClick (CloseDivisionButtonClick division.id) :: Custom.Attributes.editButton)
+        [ text "Close" ]

--- a/Frontend/src/Page/ListDivisions.elm
+++ b/Frontend/src/Page/ListDivisions.elm
@@ -110,8 +110,6 @@ update msg model =
         SeasonSortClick ->
             ( { model | sortingMethod = newSort Season SeasonDesc model.sortingMethod }, Cmd.none )
 
-        
-
 
 newSort : SortingMethod -> SortingMethod -> SortingMethod -> SortingMethod
 newSort default alt oldSort =
@@ -146,10 +144,13 @@ deleteDivisionRequest token id =
     Api.deleteRequest token (Api.Division id) <|
         Http.expectJson DivisionDeleted deleteResponseDecoder
 
+
 closeDivRequest : Maybe String -> DivisionId -> Cmd Msg
 closeDivRequest token divId =
     Api.postRequest token (Api.CloseDivision divId) Http.emptyBody <|
         Http.expectString DivisionClosed
+
+
 
 -- Helper Functions --
 
@@ -311,7 +312,7 @@ viewDivision session division =
             td (Custom.Attributes.tableButtonColumn 3)
                 [ viewCloseButton division
                 , viewEditButton division
-                , viewDeleteButton division 
+                , viewDeleteButton division
                 ]
         ]
 
@@ -329,11 +330,13 @@ viewEditButton division =
         (onClick (EditDivisionButtonClick division.id) :: Custom.Attributes.editButton)
         [ text "Edit" ]
 
+
 viewCloseButton : Division -> Html Msg
 viewCloseButton division =
     if division.closed then
         text ""
-    else 
+
+    else
         button
-        (onClick (CloseDivisionButtonClick division.id) :: Custom.Attributes.editButton)
-        [ text "Close" ]
+            (onClick (CloseDivisionButtonClick division.id) :: Custom.Attributes.editButton)
+            [ text "Close" ]

--- a/Frontend/src/Page/ListTeams.elm
+++ b/Frontend/src/Page/ListTeams.elm
@@ -339,7 +339,7 @@ viewTeam session team =
         , td []
             [ text <| String.fromInt team.elo ]
         , requiresAuth session <|
-            td [ Custom.Attributes.tableButtonColumn 2 ]
+            td ( Custom.Attributes.tableButtonColumn 2 )
                 [ viewEditButton team, viewDeleteButton team ]
         ]
 

--- a/Frontend/src/Page/ListTeams.elm
+++ b/Frontend/src/Page/ListTeams.elm
@@ -339,7 +339,7 @@ viewTeam session team =
         , td []
             [ text <| String.fromInt team.elo ]
         , requiresAuth session <|
-            td ( Custom.Attributes.tableButtonColumn 2 )
+            td (Custom.Attributes.tableButtonColumn 2)
                 [ viewEditButton team, viewDeleteButton team ]
         ]
 

--- a/Frontend/src/Page/ViewDivision.elm
+++ b/Frontend/src/Page/ViewDivision.elm
@@ -339,7 +339,7 @@ viewGamesOrError model division =
                 [ br [] []
                 , viewGamesHeader division games model.session
                 , br [] []
-                , viewGamesCarousel model games
+                , viewGamesCarousel model division games
                 ]
 
         RemoteData.Failure httpError ->
@@ -527,8 +527,8 @@ viewAddWeekButton nextWeek =
         ]
 
 
-viewGamesCarousel : Model -> List Game -> Html Msg
-viewGamesCarousel model games =
+viewGamesCarousel : Model -> Division -> List Game -> Html Msg
+viewGamesCarousel model division games =
     let
         thisId =
             "games"
@@ -539,7 +539,7 @@ viewGamesCarousel model games =
     div
         (id thisId :: Custom.Attributes.carouselContainer)
         [ carouselIndicators thisId endWeek model.displayedWeek
-        , viewGames model.session games endWeek model.displayedWeek
+        , viewGames division model.session games endWeek model.displayedWeek
         , carouselPrev model.displayedWeek
         , carouselNext model.displayedWeek endWeek
         ]
@@ -590,16 +590,16 @@ carouselNext currWeek endWeek =
         ]
 
 
-viewGames : Session -> List Game -> Int -> Int -> Html Msg
-viewGames session games endWeek currWeek =
+viewGames : Division -> Session -> List Game -> Int -> Int -> Html Msg
+viewGames division session games endWeek currWeek =
     div [ Custom.Attributes.carouselInner ]
         (List.range 1 endWeek
-            |> List.map (\week -> viewWeek session games week currWeek)
+            |> List.map (\week -> viewWeek division session games week currWeek)
         )
 
 
-viewWeek : Session -> List Game -> Int -> Int -> Html Msg
-viewWeek session games thisWeek currWeek =
+viewWeek : Division -> Session -> List Game -> Int -> Int -> Html Msg
+viewWeek division session games thisWeek currWeek =
     div
         (if thisWeek == currWeek then
             class "active" :: Custom.Attributes.carouselItem
@@ -612,7 +612,12 @@ viewWeek session games thisWeek currWeek =
             (viewWeekTitle thisWeek
                 :: (List.map (viewGame session) <| gamesInWeek thisWeek games)
             )
-            [ requiresAuth session <| viewAddGameButton thisWeek ]
+            [ if division.closed then
+                text ""
+
+              else
+                requiresAuth session <| viewAddGameButton thisWeek
+            ]
 
 
 viewWeekTitle : Int -> Html msg

--- a/Frontend/src/Page/ViewDivision.elm
+++ b/Frontend/src/Page/ViewDivision.elm
@@ -480,7 +480,7 @@ viewTeamTableRow session team =
         , td []
             [ text <| String.fromInt team.elo ]
         , requiresAuth session <|
-            td [ Custom.Attributes.tableButtonColumn 2 ]
+            td ( Custom.Attributes.tableButtonColumn 2 )
                 [ viewTeamEditButton team, viewTeamDeleteButton team ]
         ]
 

--- a/Frontend/src/Page/ViewDivision.elm
+++ b/Frontend/src/Page/ViewDivision.elm
@@ -303,19 +303,30 @@ viewTeamsOrError model =
         RemoteData.Loading ->
             h3 [] [ text "Loading..." ]
 
-        RemoteData.Success teams ->
-            div []
-                [ viewHeaderOrError model.division model.session
-                , viewTeams model teams
-                , viewGamesOrError model
-                ]
-
         RemoteData.Failure httpError ->
             viewLoadError <| Error.buildErrorMessage httpError
 
+        RemoteData.Success teams ->
+            case model.division of
+                RemoteData.Success division ->
+                    div []
+                        [ viewDivisionHeader division model.session
+                        , viewTeams model teams
+                        , viewGamesOrError model division
+                        ]
 
-viewGamesOrError : Model -> Html Msg
-viewGamesOrError model =
+                RemoteData.NotAsked ->
+                    text ""
+
+                RemoteData.Loading ->
+                    h3 [] [ text "Loading..." ]
+
+                RemoteData.Failure httpError ->
+                    viewLoadError <| Error.buildErrorMessage httpError
+
+
+viewGamesOrError : Model -> Division -> Html Msg
+viewGamesOrError model division =
     case model.games of
         RemoteData.NotAsked ->
             text ""
@@ -326,7 +337,7 @@ viewGamesOrError model =
         RemoteData.Success games ->
             div []
                 [ br [] []
-                , viewGamesHeader games model.session
+                , viewGamesHeader division games model.session
                 , br [] []
                 , viewGamesCarousel model games
                 ]
@@ -358,34 +369,22 @@ viewErrorMessage message =
             text ""
 
 
-viewHeaderOrError : WebData Division -> Session -> Html Msg
-viewHeaderOrError data session =
-    case data of
-        RemoteData.NotAsked ->
-            text ""
-
-        RemoteData.Loading ->
-            viewDivHeader "Loading..." "" session
-
-        RemoteData.Success division ->
-            viewDivHeader division.name ("Season " ++ String.fromInt division.season) session
-
-        RemoteData.Failure httpError ->
-            viewDivHeader (Error.buildErrorMessage httpError) "" session
-
-
 
 {- View Header -}
 
 
-viewDivHeader : String -> String -> Session -> Html Msg
-viewDivHeader title subtitle session =
+viewDivisionHeader : Division -> Session -> Html Msg
+viewDivisionHeader division session =
     div Custom.Attributes.row
         [ div [ Custom.Attributes.col ]
-            [ h3 [] [ text title ]
-            , h6 [] [ text subtitle ]
+            [ h3 [] [ text division.name ]
+            , h6 [] [ text <| "Season " ++ String.fromInt division.season ]
             ]
-        , div [ Custom.Attributes.col ] [ requiresAuth session viewAddTeamButton ]
+        , if division.closed then
+            text ""
+
+          else
+            div [ Custom.Attributes.col ] [ requiresAuth session viewAddTeamButton ]
         ]
 
 
@@ -480,7 +479,7 @@ viewTeamTableRow session team =
         , td []
             [ text <| String.fromInt team.elo ]
         , requiresAuth session <|
-            td ( Custom.Attributes.tableButtonColumn 2 )
+            td (Custom.Attributes.tableButtonColumn 2)
                 [ viewTeamEditButton team, viewTeamDeleteButton team ]
         ]
 
@@ -503,13 +502,17 @@ viewTeamEditButton team =
 {- View Games -}
 
 
-viewGamesHeader : List Game -> Session -> Html Msg
-viewGamesHeader games session =
+viewGamesHeader : Division -> List Game -> Session -> Html Msg
+viewGamesHeader division games session =
     div Custom.Attributes.row
         [ div [ Custom.Attributes.col ]
             [ h3 [ id "week" ] [ text "Scheduled Games" ]
             ]
-        , div [ Custom.Attributes.col ] [ requiresAuth session <| viewAddWeekButton <| maxWeek games + 1 ]
+        , if division.closed then
+            text ""
+
+          else
+            div [ Custom.Attributes.col ] [ requiresAuth session <| viewAddWeekButton <| maxWeek games + 1 ]
         ]
 
 

--- a/Frontend/src/Route.elm
+++ b/Frontend/src/Route.elm
@@ -114,7 +114,6 @@ matchRoute =
                 [ s "Division" </> s "View" </> Div.idParser </> int
                 , s "division" </> s "view" </> Div.idParser </> int
                 ]
-        
 
         {- More Complex Admin Pages -}
         , map AddTeamToDivision <|

--- a/WebApi/Handlers/DivisionHandler.fs
+++ b/WebApi/Handlers/DivisionHandler.fs
@@ -77,3 +77,16 @@ module DivisionHandler =
 
                 return! json result next ctx
             }
+
+    let closeDiv (divId) : HttpHandler =
+        fun (next : HttpFunc) (ctx : HttpContext) ->
+            task {
+                let logger = getLogger ctx
+
+                let! team = ctx.BindJsonAsync<Team>()
+                logger.LogInformation $"Closing Division: divId={divId}"
+
+                let result = DivisionService.closeDiv divId
+
+                return! json result next ctx
+            }

--- a/WebApi/Handlers/TeamHandlers.fs
+++ b/WebApi/Handlers/TeamHandlers.fs
@@ -25,6 +25,18 @@ module TeamHandler =
             }
 
 
+    let getFreeTeams : HttpHandler =
+        fun (next : HttpFunc) (ctx : HttpContext) ->
+            task {
+                let logger = getLogger ctx
+                logger.LogInformation $"Getting Teams not in any Division"
+                
+                let result = TeamService.getFree()
+
+                return! json result next ctx
+            }
+
+
     let getTeamsByDiv (divId : int) : HttpHandler =
         fun (next : HttpFunc) (ctx : HttpContext) ->
             task {

--- a/WebApi/Program.fs
+++ b/WebApi/Program.fs
@@ -67,6 +67,9 @@ let webApp =
 
                         routef "/team/updatediv/%i/%i" TeamHandler.updateDiv
                         routef "/team/updatediv/%i/%i/" TeamHandler.updateDiv
+
+                        routef "/div/close/%i" DivisionHandler.closeDiv
+                        routef "/div/close/%i/" DivisionHandler.closeDiv
                     ]
                 ]
                 PUT >=> Auth.enticate >=> choose [

--- a/WebApi/Program.fs
+++ b/WebApi/Program.fs
@@ -29,6 +29,7 @@ let webApp =
                     routef "/team/%i" TeamHandler.getTeam
                     routef "/team/%i/" TeamHandler.getTeam
 
+                    routex "/team/free(/?)" >=> TeamHandler.getFreeTeams
                     routef "/team/bydiv/%i" TeamHandler.getTeamsByDiv
                     routef "/team/bydiv/%i/" TeamHandler.getTeamsByDiv
                     routef "/team/notindiv/%i" TeamHandler.getTeamsNotInDiv

--- a/WebApi/Repos/DivisionRepository.fs
+++ b/WebApi/Repos/DivisionRepository.fs
@@ -53,5 +53,14 @@ module DivisionRepository =
             | :? MySqlException -> 0
 
 
+    let closeDiv (divId : int) =
+        use connection = new MySqlConnection(connStr)
+        connection.Open()
+
+        use db = new Database(connection)
+
+        db.Execute("CALL sp_CloseDivision(@0)", divId)
+
+
         
         

--- a/WebApi/Repos/TeamRepository.fs
+++ b/WebApi/Repos/TeamRepository.fs
@@ -25,6 +25,24 @@ module TeamRepository =
             |> List.ofSeq
 
 
+    let getFree() =  
+        use connection = new MySqlConnection(connStr)
+        connection.Open()
+
+        use db = new Database(connection)
+
+        db.Fetch<Team>("""
+                SELECT * FROM Team
+                JOIN Race ON Team.race_id=Race.id
+                JOIN Coach ON Team.coach_id=Coach.id
+                WHERE Team.id NOT IN 
+	                (SELECT Team.id FROM Team
+	                JOIN TeamDivision ON Team.id = TeamDivision.team_id
+	                WHERE TeamDivision.end_date is null)
+                """)
+            |> List.ofSeq
+
+
     let getByDiv (divId : int) =
         use connection = new MySqlConnection(connStr)
         connection.Open()

--- a/WebApi/Services/DivisionService.fs
+++ b/WebApi/Services/DivisionService.fs
@@ -19,3 +19,6 @@ module DivisionService =
 
     let saveOverId id division =
         saveChanges { division with Id = id }
+
+    let closeDiv id =
+        DivisionRepository.closeDiv id

--- a/WebApi/Services/TeamService.fs
+++ b/WebApi/Services/TeamService.fs
@@ -9,6 +9,9 @@ module TeamService =
     let getAll =
         TeamRepository.getAll
 
+    let getFree = 
+        TeamRepository.getFree
+
     let getById id =
         TeamRepository.getById id
 


### PR DESCRIPTION
Added ability to close a division, freeing all teams within it

Now only free teams can be added to a division and only open divisions can accept new teams

Closed divisions can no longer have games added to them