### PR TITLE
#67 resolves the long tail issue by capping the final calculated date

### DIFF
--- a/WebApi/Services/EloHistoryService.fs
+++ b/WebApi/Services/EloHistoryService.fs
@@ -9,12 +9,18 @@ module EloHistoryService =
 
     let getTeamEloHistory teamId =
         let team = TeamRepository.getById teamId
-        List.append 
-            (TeamEloHistoryRepository.getByTeam teamId)
-            [{ Id = 0; TeamId = teamId; Elo = team.Elo; Date = DateTime.Now }] 
+        let history = TeamEloHistoryRepository.getByTeam teamId
+        let weekAfterFinal = (history.Item (history.Length - 1)).Date.AddDays(7)
+        let clampedFinal = if (weekAfterFinal > DateTime.Now) then DateTime.Now else weekAfterFinal
+        
+        List.append history
+            [{ Id = 0; TeamId = teamId; Elo = team.Elo; Date = clampedFinal }] 
 
     let getCoachEloHistory coachId =
         let coach = CoachRepository.getById coachId
-        List.append
-            (CoachEloHistoryRepository.getByCoach coachId)
-            [{ Id = 0; CoachId = coachId; Elo = coach.Elo; Date = DateTime.Now }]
+        let history = CoachEloHistoryRepository.getByCoach coachId
+        let weekAfterFinal = (history.Item (history.Length - 1)).Date.AddDays(7)
+        let clampedFinal = if (weekAfterFinal > DateTime.Now) then DateTime.Now else weekAfterFinal
+        
+        List.append history
+            [{ Id = 0; CoachId = coachId; Elo = coach.Elo; Date = clampedFinal }]


### PR DESCRIPTION
#67 more accurately represent the final datapoint in elo history